### PR TITLE
Persist invited users

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,13 +80,22 @@ pub struct ListTeamParams {
 #[derive(Debug)]
 pub enum ExitError {
     Io(std::io::Error),
+    InvalidGitHubID(std::num::ParseIntError),
     Serde(serde_json::error::Error),
 }
+
 impl From<std::io::Error> for ExitError {
     fn from(e: std::io::Error) -> Self {
         Self::Io(e)
     }
 }
+
+impl From<std::num::ParseIntError> for ExitError {
+    fn from(e: std::num::ParseIntError) -> Self {
+        Self::InvalidGitHubID(e)
+    }
+}
+
 impl From<serde_json::error::Error> for ExitError {
     fn from(e: serde_json::error::Error) -> Self {
         Self::Serde(e)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,7 +75,7 @@ pub struct SyncTeamParams {
     /// guarantees that users that have been previously invited and rejected
     /// will not keep getting spammed.
     #[structopt(long = "invited-list", parse(from_os_str))]
-    pub invited_list: Option<PathBuf>,
+    pub invited_list: PathBuf,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,6 +71,9 @@ pub struct SyncTeamParams {
     #[structopt(long = "limit")]
     pub limit: Option<u64>,
 
+    /// File to track previously invited users. Setting this parameter
+    /// guarantees that users that have been previously invited and rejected
+    /// will not keep getting spammed.
     #[structopt(long = "invited-list")]
     pub invited_list: Option<PathBuf>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,9 @@ pub struct SyncTeamParams {
 
     #[structopt(long = "limit")]
     pub limit: Option<u64>,
+
+    #[structopt(long = "invited-list")]
+    pub invited_list: Option<PathBuf>,
 }
 
 #[derive(Debug, StructOpt)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,7 +74,7 @@ pub struct SyncTeamParams {
     /// File to track previously invited users. Setting this parameter
     /// guarantees that users that have been previously invited and rejected
     /// will not keep getting spammed.
-    #[structopt(long = "invited-list")]
+    #[structopt(long = "invited-list", parse(from_os_str))]
     pub invited_list: Option<PathBuf>,
 }
 

--- a/src/invited.rs
+++ b/src/invited.rs
@@ -78,9 +78,11 @@ impl Invited {
             err
         })?;
 
-        let string = self
-            .invited
-            .iter()
+        let mut values = self.invited.iter().collect::<Vec<_>>();
+        values.sort();
+
+        let string = values
+            .into_iter()
             .map(|id| id.to_string())
             .collect::<Vec<_>>()
             .join("\n");

--- a/src/invited.rs
+++ b/src/invited.rs
@@ -11,6 +11,7 @@ pub struct Invited {
 }
 
 impl Invited {
+    #[cfg(test)]
     pub fn new() -> Invited {
         Invited {
             invited: HashSet::new(),

--- a/src/invited.rs
+++ b/src/invited.rs
@@ -6,18 +6,18 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
-pub struct Invites {
+pub struct Invited {
     invited: HashSet<GitHubID>,
 }
 
-impl Invites {
-    pub fn new() -> Invites {
-        Invites {
+impl Invited {
+    pub fn new() -> Invited {
+        Invited {
             invited: HashSet::new(),
         }
     }
 
-    pub fn load(path: &Path) -> Result<Invites, ExitError> {
+    pub fn load(path: &Path) -> Result<Invited, ExitError> {
         let file = File::open(path)?;
         let lines = BufReader::new(file).lines();
 
@@ -26,7 +26,7 @@ impl Invites {
             invited.insert(GitHubID::new(line?.parse()?));
         }
 
-        Ok(Invites { invited })
+        Ok(Invited { invited })
     }
 
     pub fn save(&self, path: &Path) -> Result<(), ExitError> {
@@ -44,15 +44,15 @@ impl Invites {
         Ok(())
     }
 
-    pub fn invited(&self, id: &GitHubID) -> bool {
+    pub fn contains(&self, id: &GitHubID) -> bool {
         self.invited.contains(id)
     }
 
-    pub fn add_invite(&mut self, id: GitHubID) {
+    pub fn add(&mut self, id: GitHubID) {
         self.invited.insert(id);
     }
 
-    pub fn remove_invite(&mut self, id: &GitHubID) {
+    pub fn remove(&mut self, id: &GitHubID) {
         self.invited.remove(id);
     }
 }
@@ -63,31 +63,31 @@ mod tests {
 
     #[test]
     fn test_load_save() {
-        let mut invites = Invites::new();
+        let mut invited = Invited::new();
         let tmpdir = tempfile::tempdir().unwrap();
-        let tmpfile = tmpdir.path().join("invites.txt");
+        let tmpfile = tmpdir.path().join("invited.txt");
 
         for n in (0..20).step_by(3) {
-            invites.add_invite(GitHubID::new(n));
+            invited.add(GitHubID::new(n));
         }
 
-        invites.save(&tmpfile).unwrap();
+        invited.save(&tmpfile).unwrap();
 
-        let loaded_invites = Invites::load(&tmpfile).unwrap();
+        let loaded_invited = Invited::load(&tmpfile).unwrap();
 
-        assert_eq!(invites, loaded_invites);
+        assert_eq!(invited, loaded_invited);
     }
 
     #[test]
-    fn test_add_remove_invites() {
-        let mut invites = Invites::new();
+    fn test_add_remove_invited() {
+        let mut invited = Invited::new();
 
-        assert!(!invites.invited(&GitHubID::new(0)));
+        assert!(!invited.contains(&GitHubID::new(0)));
 
-        invites.add_invite(GitHubID::new(0));
-        assert!(invites.invited(&GitHubID::new(0)));
+        invited.add(GitHubID::new(0));
+        assert!(invited.contains(&GitHubID::new(0)));
 
-        invites.remove_invite(&GitHubID::new(0));
-        assert!(!invites.invited(&GitHubID::new(0)));
+        invited.remove(&GitHubID::new(0));
+        assert!(!invited.contains(&GitHubID::new(0)));
     }
 }

--- a/src/invited.rs
+++ b/src/invited.rs
@@ -96,6 +96,10 @@ impl Invited {
         Ok(())
     }
 
+    pub fn len(&self) -> usize {
+        self.invited.len()
+    }
+
     pub fn contains(&self, id: &GitHubID) -> bool {
         self.invited.contains(id)
     }
@@ -127,6 +131,8 @@ mod tests {
 
         let loaded_invited = Invited::load(rfc39::test_logger(), &tmpfile).unwrap();
 
+        assert_eq!(invited.len(), loaded_invited.len());
+
         assert_eq!(invited, loaded_invited);
     }
 
@@ -147,9 +153,11 @@ mod tests {
         assert!(!invited.contains(&GitHubID::new(0)));
 
         invited.add(GitHubID::new(0));
+        assert_eq!(invited.len(), 1);
         assert!(invited.contains(&GitHubID::new(0)));
 
         invited.remove(&GitHubID::new(0));
+        assert_eq!(invited.len(), 0);
         assert!(!invited.contains(&GitHubID::new(0)));
     }
 }

--- a/src/invites.rs
+++ b/src/invites.rs
@@ -6,12 +6,11 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::Path;
 
 #[cfg_attr(test, derive(Debug, PartialEq))]
-struct Invites {
+pub struct Invites {
     invited: HashSet<GitHubID>,
 }
 
 impl Invites {
-    #[cfg(test)]
     pub fn new() -> Invites {
         Invites {
             invited: HashSet::new(),
@@ -88,7 +87,7 @@ mod tests {
         invites.add_invite(GitHubID::new(0));
         assert!(invites.invited(&GitHubID::new(0)));
 
-        invites.remove_invite(GitHubID::new(0));
+        invites.remove_invite(&GitHubID::new(0));
         assert!(!invites.invited(&GitHubID::new(0)));
     }
 }

--- a/src/invites.rs
+++ b/src/invites.rs
@@ -1,0 +1,94 @@
+use crate::cli::ExitError;
+use crate::maintainers::GitHubID;
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+
+#[cfg_attr(test, derive(Debug, PartialEq))]
+struct Invites {
+    invited: HashSet<GitHubID>,
+}
+
+impl Invites {
+    #[cfg(test)]
+    pub fn new() -> Invites {
+        Invites {
+            invited: HashSet::new(),
+        }
+    }
+
+    pub fn load(path: &Path) -> Result<Invites, ExitError> {
+        let file = File::open(path)?;
+        let lines = BufReader::new(file).lines();
+
+        let mut invited = HashSet::new();
+        for line in lines {
+            invited.insert(GitHubID::new(line?.parse()?));
+        }
+
+        Ok(Invites { invited })
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), ExitError> {
+        let mut file = File::create(path)?;
+
+        let string = self
+            .invited
+            .iter()
+            .map(|id| id.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        file.write_all(string.as_ref())?;
+
+        Ok(())
+    }
+
+    pub fn invited(&self, id: &GitHubID) -> bool {
+        self.invited.contains(id)
+    }
+
+    pub fn add_invite(&mut self, id: GitHubID) {
+        self.invited.insert(id);
+    }
+
+    pub fn remove_invite(&mut self, id: &GitHubID) {
+        self.invited.remove(id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_load_save() {
+        let mut invites = Invites::new();
+        let tmpdir = tempfile::tempdir().unwrap();
+        let tmpfile = tmpdir.path().join("invites.txt");
+
+        for n in (0..20).step_by(3) {
+            invites.add_invite(GitHubID::new(n));
+        }
+
+        invites.save(&tmpfile).unwrap();
+
+        let loaded_invites = Invites::load(&tmpfile).unwrap();
+
+        assert_eq!(invites, loaded_invites);
+    }
+
+    #[test]
+    fn test_add_remove_invites() {
+        let mut invites = Invites::new();
+
+        assert!(!invites.invited(&GitHubID::new(0)));
+
+        invites.add_invite(GitHubID::new(0));
+        assert!(invites.invited(&GitHubID::new(0)));
+
+        invites.remove_invite(GitHubID::new(0));
+        assert!(!invites.invited(&GitHubID::new(0)));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,11 +175,11 @@ fn execute_ops(logger: slog::Logger, inputs: Options) -> Result<(), ExitError> {
             logger.new(o!("exec-mode" => "SyncTeam")),
             github,
             maintainers,
+            team_info.invited_list,
             &team_info.organization,
             team_info.team_id,
             team_info.dry_run,
             team_info.limit,
-            team_info.invited_list,
         ),
         ExecMode::ListTeams(team_info) => op_sync_team::list_teams(github, &team_info.organization),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 mod cli;
 use cli::{ExecMode, ExitError, Options};
-mod invites;
+mod invited;
 mod maintainers;
 use maintainers::MaintainerList;
 mod filemunge;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 mod cli;
 use cli::{ExecMode, ExitError, Options};
+mod invites;
 mod maintainers;
 use maintainers::MaintainerList;
 mod filemunge;

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ fn execute_ops(logger: slog::Logger, inputs: Options) -> Result<(), ExitError> {
             team_info.team_id,
             team_info.dry_run,
             team_info.limit,
+            team_info.invited_list,
         ),
         ExecMode::ListTeams(team_info) => op_sync_team::list_teams(github, &team_info.organization),
     }

--- a/src/maintainers.rs
+++ b/src/maintainers.rs
@@ -53,7 +53,7 @@ impl GitHubName {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Deserialize)]
 pub struct GitHubID(u64);
 impl std::fmt::Display for GitHubID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/nix.rs
+++ b/src/nix.rs
@@ -50,7 +50,7 @@ where
         cmd.arg(val);
     }
 
-    let output = cmd.output().expect("F;ailed to start nix-instantiate!");
+    let output = cmd.output().expect("Failed to start nix-instantiate!");
 
     if !output.stderr.is_empty() {
         warn!(logger, "Stderr from nix-instantiate";

--- a/src/op_sync_team.rs
+++ b/src/op_sync_team.rs
@@ -146,7 +146,7 @@ pub fn sync_team(
 
     current_team_member_gauge.set(current_members.len().try_into().unwrap());
 
-    let mut invited = Invited::load(&invited_list)?;
+    let mut invited = Invited::load(logger.clone(), &invited_list)?;
 
     debug!(logger, "Fetching existing invitations");
     let pending_invites: Vec<GitHubName> = rt

--- a/src/op_sync_team.rs
+++ b/src/op_sync_team.rs
@@ -228,7 +228,7 @@ pub fn sync_team(
         if let Some(limit) = limit {
             if (additions.get() + removals.get()) >= limit {
                 info!(logger, "Hit maximum change limit");
-                return Ok(());
+                break;
             }
         }
         match action {

--- a/src/op_sync_team.rs
+++ b/src/op_sync_team.rs
@@ -464,12 +464,16 @@ mod tests {
             vec![
                 (
                     GitHubID::new(1),
-                    TeamAction::Remove(GitHubName::new("alice"))
+                    TeamAction::Remove(GitHubName::new("alice"), GitHubID::new(1))
                 ),
                 (GitHubID::new(2), TeamAction::Keep(Handle::new("bob"))),
                 (
                     GitHubID::new(3),
-                    TeamAction::Add(GitHubName::new("charlie"), Handle::new("charlie"))
+                    TeamAction::Add(
+                        GitHubName::new("charlie"),
+                        GitHubID::new(3),
+                        Handle::new("charlie")
+                    )
                 ),
             ]
             .into_iter()

--- a/src/op_sync_team.rs
+++ b/src/op_sync_team.rs
@@ -34,11 +34,11 @@ pub fn sync_team(
     logger: slog::Logger,
     github: Github,
     maintainers: MaintainerList,
+    invited_list: PathBuf,
     org: &str,
     team_id: u64,
     dry_run: bool,
     limit: Option<u64>,
-    invited_list: Option<PathBuf>,
 ) -> Result<(), ExitError> {
     // initialize the counters :(
     GITHUB_CALLS.get();
@@ -146,11 +146,7 @@ pub fn sync_team(
 
     current_team_member_gauge.set(current_members.len().try_into().unwrap());
 
-    let mut invited = if let Some(ref invited_list) = invited_list {
-        Invited::load(invited_list)?
-    } else {
-        Invited::new()
-    };
+    let mut invited = Invited::load(&invited_list)?;
 
     debug!(logger, "Fetching existing invitations");
     let pending_invites: Vec<GitHubName> = rt
@@ -337,9 +333,7 @@ pub fn sync_team(
         }
     }
 
-    if let Some(ref invited_list) = invited_list {
-        invited.save(invited_list)?;
-    }
+    invited.save(&invited_list)?;
 
     Ok(())
 }

--- a/src/op_sync_team.rs
+++ b/src/op_sync_team.rs
@@ -216,9 +216,13 @@ pub fn sync_team(
                     "nixpkgs-handle" => format!("{}", handle),
                     "github-name" => format!("{}", github_name),
                 ));
-                if pending_invites.contains(&github_name) || invited.contains(&github_id) {
+
+                if pending_invites.contains(&github_name) {
                     noops.inc();
-                    debug!(logger, "User has already been invited previously and/or still has a pending invitation");
+                    debug!(logger, "User already has a pending invitation");
+                } else if invited.contains(&github_id) {
+                    noops.inc();
+                    debug!(logger, "User was already invited previously (since there's no pending invitation we can assume the user rejected the invite)");
                 } else {
                     additions.inc();
                     info!(logger, "Adding user to the team");

--- a/src/op_sync_team.rs
+++ b/src/op_sync_team.rs
@@ -110,6 +110,18 @@ pub fn sync_team(
     )
     .unwrap();
 
+    let invited_list_loaded_gauge: IntGauge = register_int_gauge!(
+        "rfc39_invited_list_loaded",
+        "Number of github ids loaded from the previously invited list"
+    )
+    .unwrap();
+
+    let invited_list_saved_gauge: IntGauge = register_int_gauge!(
+        "rfc39_invited_list_saved",
+        "Number of github ids saved to the previously invited list"
+    )
+    .unwrap();
+
     let mut rt = TrackedReactor {
         rt: Runtime::new().unwrap(),
     };
@@ -147,6 +159,7 @@ pub fn sync_team(
     current_team_member_gauge.set(current_members.len().try_into().unwrap());
 
     let mut invited = Invited::load(logger.clone(), &invited_list)?;
+    invited_list_loaded_gauge.set(invited.len().try_into().unwrap());
 
     debug!(logger, "Fetching existing invitations");
     let pending_invites: Vec<GitHubName> = rt
@@ -348,6 +361,7 @@ pub fn sync_team(
     }
 
     invited.save(&invited_list)?;
+    invited_list_saved_gauge.set(invited.len().try_into().unwrap());
 
     Ok(())
 }


### PR DESCRIPTION
Fix #3.

An option `--invited-list` is added which takes a file path where github ids of invited users will be persisted. This is a plain text file where one github id (a number) is stored per line (this makes it easy to manually edit).